### PR TITLE
Insert parentheses around sub-clauses joined by AND

### DIFF
--- a/src/utils/database/uploadsFilterWhereClause.ts
+++ b/src/utils/database/uploadsFilterWhereClause.ts
@@ -62,9 +62,9 @@ export class UploadsFilterWhereClause {
       return null;
     }
 
-    return `${options.includeWhereKeyword ? 'WHERE ' : ''}${subClauses.join(
-      ' AND ',
-    )}`;
+    const condition = subClauses.map((clause) => `(${clause})`).join(' AND ');
+
+    return `${options.includeWhereKeyword ? 'WHERE ' : ''}${condition}`;
   }
 
   uploadsClause(options: ClauseCreationOptions): string | null {


### PR DESCRIPTION
Else we run into operator precendence issues when one of the sub-clauses contains an OR.