### PR TITLE
Move repo out of filter

### DIFF
--- a/src/failures/failure.viewModel.ts
+++ b/src/failures/failure.viewModel.ts
@@ -2,9 +2,11 @@ import { DescriptionListViewModel } from '../utils/view/descriptionList';
 import { Failure } from '../uploads/failure.entity';
 import { ViewModelURLHelpers } from 'src/utils/viewModel/urlHelpers';
 import { UploadsFilter } from 'src/uploads/uploads.service';
+import { Repo } from 'src/repos/repo';
 
 export class FailureViewModel {
   constructor(
+    private readonly repo: Repo,
     private readonly failure: Failure,
     private readonly filter: UploadsFilter,
   ) {}
@@ -20,7 +22,7 @@ export class FailureViewModel {
           text: this.failure.uploadId,
           href: ViewModelURLHelpers.hrefForUploadDetails(
             this.failure.uploadId,
-            this.filter,
+            this.repo,
           ),
         },
       },
@@ -31,6 +33,7 @@ export class FailureViewModel {
           text: this.failure.testCase.id,
           href: ViewModelURLHelpers.hrefForTestCase(
             this.failure.testCase.id,
+            this.repo,
             this.filter,
           ),
         },

--- a/src/failures/failures.controller.ts
+++ b/src/failures/failures.controller.ts
@@ -3,7 +3,7 @@ import { ControllerUtils } from 'src/utils/controller/utils';
 import { FailureViewModel } from './failure.viewModel';
 import { FailuresService } from './failures.service';
 
-@Controller('repos/:owner/:repo/failures')
+@Controller('repos/:owner/:name/failures')
 export class FailuresController {
   constructor(private readonly failuresService: FailuresService) {}
 
@@ -11,7 +11,7 @@ export class FailuresController {
   @Render('failures/details')
   async failureDetails(
     @Param('owner') owner: string,
-    @Param('repo') repo: string,
+    @Param('name') name: string,
     @Param('id') id: string,
     @Query('branches') branches: string[] | undefined,
     @Query('createdBefore') createdBefore: string | undefined,
@@ -20,15 +20,14 @@ export class FailuresController {
   ): Promise<{ viewModel: FailureViewModel }> {
     const failure = await this.failuresService.find(id);
 
+    const repo = ControllerUtils.createRepoFromQuery(owner, name);
     const filter = ControllerUtils.createFilterFromQuery(
-      owner,
-      repo,
       branches,
       createdBefore,
       createdAfter,
       failureMessage,
     );
 
-    return { viewModel: new FailureViewModel(failure, filter) };
+    return { viewModel: new FailureViewModel(repo, failure, filter) };
   }
 }

--- a/src/repos/repo.ts
+++ b/src/repos/repo.ts
@@ -1,0 +1,4 @@
+export interface Repo {
+  owner: string;
+  name: string;
+}

--- a/src/testCases/testCase.viewModel.ts
+++ b/src/testCases/testCase.viewModel.ts
@@ -1,4 +1,5 @@
 import pluralize from 'pluralize';
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 import { DescriptionListViewModel } from 'src/utils/view/descriptionList';
 import { ViewModelHelpers } from 'src/utils/viewModel/helpers';
@@ -8,11 +9,15 @@ import { TableViewModel } from '../utils/view/table';
 
 export class TestCaseViewModel {
   constructor(
+    private readonly repo: Repo,
     private readonly testCase: TestCase,
     private readonly filter: UploadsFilter,
   ) {}
 
-  readonly filterDescription = ViewModelHelpers.viewModelForFilter(this.filter);
+  readonly filterDescription = ViewModelHelpers.viewModelForFilter(
+    this.repo,
+    this.filter,
+  );
 
   get heading(): string {
     return `Details of test case ${this.testCase.id}`;
@@ -44,14 +49,14 @@ export class TestCaseViewModel {
       {
         type: 'link',
         text: failure.id,
-        href: ViewModelURLHelpers.hrefForFailure(failure.id, this.filter),
+        href: ViewModelURLHelpers.hrefForFailure(failure.id, this.repo),
       },
       {
         type: 'link',
         text: failure.uploadId,
         href: ViewModelURLHelpers.hrefForUploadDetails(
           failure.uploadId,
-          this.filter,
+          this.repo,
         ),
       },
       { type: 'text', text: failure.upload.createdAt.toISOString() },

--- a/src/testCases/testCases.service.ts
+++ b/src/testCases/testCases.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 import { UploadsFilterWhereClause } from 'src/utils/database/uploadsFilterWhereClause';
 import { Repository } from 'typeorm';
@@ -14,9 +15,16 @@ export class TestCasesService {
 
   // Includes failures, but not their uploads (except for createdAt).
   // TODO find a good way to represent this in the type system
-  async find(id: string, failuresFilter: UploadsFilter): Promise<TestCase> {
+  async find(
+    id: string,
+    repo: Repo,
+    failuresFilter: UploadsFilter,
+  ): Promise<TestCase> {
     const whereClause =
-      UploadsFilterWhereClause.createFromFilterUsingNamedParams(failuresFilter);
+      UploadsFilterWhereClause.createFromFilterUsingNamedParams(
+        repo,
+        failuresFilter,
+      );
 
     let queryBuilder = this.testCasesRepository
       .createQueryBuilder('testCase')

--- a/src/uploads/details.viewModel.ts
+++ b/src/uploads/details.viewModel.ts
@@ -1,4 +1,5 @@
 import pluralize from 'pluralize';
+import { Repo } from 'src/repos/repo';
 import { DescriptionListViewModel } from 'src/utils/view/descriptionList';
 import { ViewModelURLHelpers } from 'src/utils/viewModel/urlHelpers';
 import { TableViewModel } from '../utils/view/table';
@@ -8,6 +9,7 @@ import { UploadsFilter } from './uploads.service';
 export class UploadDetailsViewModel {
   constructor(
     private readonly upload: Upload,
+    private readonly repo: Repo,
     private readonly filter: UploadsFilter,
   ) {}
 
@@ -32,13 +34,14 @@ export class UploadDetailsViewModel {
       {
         type: 'link',
         text: failure.id,
-        href: ViewModelURLHelpers.hrefForFailure(failure.id, this.filter),
+        href: ViewModelURLHelpers.hrefForFailure(failure.id, this.repo),
       },
       {
         type: 'link',
         text: failure.testCase.id,
         href: ViewModelURLHelpers.hrefForTestCase(
           failure.testCase.id,
+          this.repo,
           this.filter,
         ),
       },
@@ -68,7 +71,7 @@ export class UploadDetailsViewModel {
           text: 'View report',
           href: ViewModelURLHelpers.hrefForJunitReportXml(
             this.upload.id,
-            this.filter,
+            this.repo,
           ),
         },
       },

--- a/src/uploads/filter.viewModel.ts
+++ b/src/uploads/filter.viewModel.ts
@@ -1,12 +1,14 @@
+import { Repo } from 'src/repos/repo';
 import { CheckboxesViewModel } from 'src/utils/view/checkboxes';
 import { InputViewModel } from 'src/utils/view/input';
 import { ViewModelURLHelpers } from 'src/utils/viewModel/urlHelpers';
 import { UploadsFilter } from './uploads.service';
 
 export class FilterViewModel {
-  readonly formAction = ViewModelURLHelpers.hrefForUploads(this.filter);
+  readonly formAction = ViewModelURLHelpers.hrefForUploads(this.repo);
 
   constructor(
+    private readonly repo: Repo,
     private readonly filter: UploadsFilter,
     private readonly availableBranches: string[],
   ) {}

--- a/src/uploads/overview.viewModel.ts
+++ b/src/uploads/overview.viewModel.ts
@@ -4,15 +4,20 @@ import { UploadsReport, FailuresOverviewReport } from './reports.service';
 import { UploadsFilter } from './uploads.service';
 import { ViewModelHelpers } from '../utils/viewModel/helpers';
 import { ViewModelURLHelpers } from 'src/utils/viewModel/urlHelpers';
+import { Repo } from 'src/repos/repo';
 
 export class OverviewViewModel {
   constructor(
+    private readonly repo: Repo,
     private readonly uploadsReport: UploadsReport,
     private readonly failuresOverviewReport: FailuresOverviewReport,
     private readonly filter: UploadsFilter,
   ) {}
 
-  readonly filterDescription = ViewModelHelpers.viewModelForFilter(this.filter);
+  readonly filterDescription = ViewModelHelpers.viewModelForFilter(
+    this.repo,
+    this.filter,
+  );
 
   private readonly numberOfUploadsWithFailures = this.uploadsReport.filter(
     (upload) => upload.numberOfFailures > 0,
@@ -35,7 +40,7 @@ export class OverviewViewModel {
           text: entry.upload.id,
           href: ViewModelURLHelpers.hrefForUploadDetails(
             entry.upload.id,
-            this.filter,
+            this.repo,
           ),
         },
         { type: 'text', text: entry.upload.createdAt.toISOString() },
@@ -90,6 +95,7 @@ export class OverviewViewModel {
         text: entry.testCase.id,
         href: ViewModelURLHelpers.hrefForTestCase(
           entry.testCase.id,
+          this.repo,
           this.filter,
         ),
       },
@@ -122,7 +128,7 @@ export class OverviewViewModel {
         text: entry.lastSeenIn.createdAt.toISOString(),
         href: ViewModelURLHelpers.hrefForUploadDetails(
           entry.lastSeenIn.id,
-          this.filter,
+          this.repo,
         ),
       },
     ]),

--- a/src/uploads/uploads.service.ts
+++ b/src/uploads/uploads.service.ts
@@ -7,8 +7,6 @@ import { TestCase } from './testCase.entity';
 import { Upload } from './upload.entity';
 
 export interface UploadsFilter {
-  owner: string;
-  repo: string;
   // empty implies no branches filter
   branches: string[];
   createdBefore: Date | null;

--- a/src/utils/controller/utils.ts
+++ b/src/utils/controller/utils.ts
@@ -1,9 +1,12 @@
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 
 export class ControllerUtils {
+  static createRepoFromQuery(owner: string, name: string): Repo {
+    return { owner, name };
+  }
+
   static createFilterFromQuery(
-    owner: string,
-    repo: string,
     branches: string[] | undefined,
     createdBefore: string | undefined,
     createdAfter: string | undefined,
@@ -25,8 +28,6 @@ export class ControllerUtils {
     }
 
     return {
-      owner: owner,
-      repo: repo,
       branches: branches ?? [],
       createdBefore: createdBeforeDate,
       createdAfter: createdAfterDate,

--- a/src/utils/database/uploadsFilterWhereClause.ts
+++ b/src/utils/database/uploadsFilterWhereClause.ts
@@ -1,3 +1,4 @@
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 
 interface ClauseCreationOptions {
@@ -12,9 +13,11 @@ export class UploadsFilterWhereClause<Params> {
   ) {}
 
   static createFromFilterUsingPositionalParams(
+    repo: Repo,
     filter: UploadsFilter,
   ): UploadsFilterWhereClause<unknown[]> {
     return this.createFromFilter<unknown[]>(
+      repo,
       filter,
       [],
       (i) => `$${i}`,
@@ -26,9 +29,11 @@ export class UploadsFilterWhereClause<Params> {
   }
 
   static createFromFilterUsingNamedParams(
+    repo: Repo,
     filter: UploadsFilter,
   ): UploadsFilterWhereClause<Record<string, unknown>> {
     return this.createFromFilter<Record<string, unknown>>(
+      repo,
       filter,
       {},
       (i) => `:uploadsFilterParam${i}`,
@@ -40,6 +45,7 @@ export class UploadsFilterWhereClause<Params> {
   }
 
   private static createFromFilter<Params>(
+    repo: Repo,
     filter: UploadsFilter,
     initialParams: Params,
     createParamName: (index: number) => string,
@@ -68,7 +74,7 @@ export class UploadsFilterWhereClause<Params> {
     uploadsSubClauses.push(
       `uploads.github_repository = ${createParamName(parameterCount)}`,
     );
-    params = addParam(parameterCount, filter.owner + '/' + filter.repo, params);
+    params = addParam(parameterCount, repo.owner + '/' + repo.name, params);
 
     if (filter.createdBefore) {
       parameterCount += 1;

--- a/src/utils/viewModel/helpers.ts
+++ b/src/utils/viewModel/helpers.ts
@@ -1,4 +1,5 @@
 import pluralize from 'pluralize';
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 import { FilterDescriptionViewModel } from '../view/filterDescription';
 import { ViewModelURLHelpers } from './urlHelpers';
@@ -22,23 +23,24 @@ export class ViewModelHelpers {
     return ` (${formattedPercentage})`;
   }
 
-  static viewModelForFilter(filter: UploadsFilter): FilterDescriptionViewModel {
+  static viewModelForFilter(
+    repo: Repo,
+    filter: UploadsFilter,
+  ): FilterDescriptionViewModel {
     return {
-      summary: this.summaryForFilter(filter),
+      summary: this.summaryForFilter(repo, filter),
       filterLink: {
         text: 'Filter results',
-        href: ViewModelURLHelpers.hrefForFilterOptions(filter),
+        href: ViewModelURLHelpers.hrefForFilterOptions(repo, filter),
       },
     };
   }
 
-  private static summaryForFilter(filter: UploadsFilter) {
+  private static summaryForFilter(repo: Repo, filter: UploadsFilter) {
     const uploadsComponents: string[] = [];
     const failuresComponents: string[] = [];
 
-    uploadsComponents.push(
-      `belonging to the ${filter.owner}/${filter.repo} repo`,
-    );
+    uploadsComponents.push(`belonging to the ${repo.owner}/${repo.name} repo`);
 
     if (filter.branches.length > 0) {
       uploadsComponents.push(

--- a/src/utils/viewModel/urlHelpers.ts
+++ b/src/utils/viewModel/urlHelpers.ts
@@ -1,9 +1,8 @@
+import { Repo } from 'src/repos/repo';
 import { UploadsFilter } from 'src/uploads/uploads.service';
 
-function repoSlug(filter: UploadsFilter): string {
-  return (
-    encodeURIComponent(filter.owner) + '/' + encodeURIComponent(filter.repo)
-  );
+function repoSlug(repo: Repo): string {
+  return encodeURIComponent(repo.owner) + '/' + encodeURIComponent(repo.name);
 }
 
 export class ViewModelURLHelpers {
@@ -11,17 +10,17 @@ export class ViewModelURLHelpers {
     return `/repos/${this.encodeRepoName(repo)}/uploads`;
   }
 
-  static hrefForUploads(filter: UploadsFilter) {
-    return `/repos/${repoSlug(filter)}/uploads`;
+  static hrefForUploads(repo: Repo) {
+    return `/repos/${repoSlug(repo)}/uploads`;
   }
 
-  static hrefForUploadDetails(id: string, filter: UploadsFilter) {
-    return `/repos/${repoSlug(filter)}/uploads/${encodeURIComponent(id)}`;
+  static hrefForUploadDetails(id: string, repo: Repo) {
+    return `/repos/${repoSlug(repo)}/uploads/${encodeURIComponent(id)}`;
   }
 
-  static hrefForTestCase(id: string, filter: UploadsFilter) {
+  static hrefForTestCase(id: string, repo: Repo, filter: UploadsFilter) {
     return this.hrefWithFilter(
-      `/repos/${repoSlug(filter)}/test_cases/${encodeURIComponent(id)}`,
+      `/repos/${repoSlug(repo)}/test_cases/${encodeURIComponent(id)}`,
       filter,
     );
   }
@@ -56,12 +55,12 @@ export class ViewModelURLHelpers {
     )}/actions/runs/${runId}/attempts/${runAttempt}`;
   }
 
-  static hrefForJunitReportXml(id: string, filter: UploadsFilter) {
-    return `/repos/${repoSlug(filter)}/uploads/${id}/junit_report_xml`;
+  static hrefForJunitReportXml(id: string, repo: Repo) {
+    return `/repos/${repoSlug(repo)}/uploads/${id}/junit_report_xml`;
   }
 
-  static hrefForFailure(id: string, filter: UploadsFilter) {
-    return `/repos/${repoSlug(filter)}/failures/${encodeURIComponent(id)}`;
+  static hrefForFailure(id: string, repo: Repo) {
+    return `/repos/${repoSlug(repo)}/failures/${encodeURIComponent(id)}`;
   }
 
   static queryFragmentForFilter(filter: UploadsFilter): string {
@@ -109,9 +108,9 @@ export class ViewModelURLHelpers {
     }
   }
 
-  static hrefForFilterOptions(filter: UploadsFilter) {
+  static hrefForFilterOptions(repo: Repo, filter: UploadsFilter) {
     return this.hrefWithFilter(
-      `/repos/${repoSlug(filter)}/uploads/filter`,
+      `/repos/${repoSlug(repo)}/uploads/filter`,
       filter,
     );
   }


### PR DESCRIPTION
It doesn't make sense once we start dealing with pages that use multiple filters, which still must refer to the same repo (e.g. the uploads comparison page I’m working on).